### PR TITLE
Removed multithreading and added JSON helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ api = API()
 cpu_data = api.retrieve("cpu")
 all_data = api.retrieve_all()
 ```
+`api.retrieve()` and `api.retrieve_all()` methods both return a `PartData` instance, which contains a timestamp and a `to_json()` method. 
 
 A list of supported parts can be obtained in the following manner:
 ```python

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![](https://img.shields.io/pypi/dm/pcpartpicker.svg)
 
 This is an unofficial Python 3.7+ API for the website pcpartpicker.com.
-It is written using asynchronous code and multiprocessing for efficient data retrieval. 
+It is written using asynchronous requests for efficient data retrieval. 
 This package is currently in a stable beta.
 
 ## Installation:

--- a/pcpartpicker/__init__.py
+++ b/pcpartpicker/__init__.py
@@ -1,6 +1,6 @@
 from .api import API
 
 __name__ = ["pcpartpicker"]
-__version__ = '2.1.1'
+__version__ = '2.2.0'
 __author__ = 'Jonathan Vusich'
 __email__ = 'jonathanvusich@gmail.com'

--- a/pcpartpicker/api.py
+++ b/pcpartpicker/api.py
@@ -2,6 +2,7 @@ import logging
 from typing import Set, Dict, List
 
 from .handler import Handler
+from .part_data import PartData
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN)
@@ -14,12 +15,8 @@ class API:
     the internals and the externally available functions.
     """
 
-    def __init__(self, region: str = "us", multithreading=True) -> None:
-        self._handler = Handler(region, multithreading=multithreading)
-
-    @property
-    def multithreading(self) -> bool:
-        return self._handler.multithreading
+    def __init__(self, region: str = "us") -> None:
+        self._handler = Handler(region)
 
     @property
     def supported_regions(self) -> Set[str]:
@@ -44,17 +41,7 @@ class API:
         self._handler.set_region(region)
         logger.debug(f"Region set to {self.region}")
 
-    def set_multithreading(self, multithreading: bool) -> None:
-        """
-        Function that allows the user to determine whether the scraped HTML is parsed using multiple threads or not.
-        Single threading is especially useful for debugging purposes.
-        :param multithreading:
-        :return:
-        """
-        self._handler.set_multithreading(multithreading)
-        logger.debug(f"Multithreading set to {self.multithreading}")
-
-    def retrieve(self, *args, force_refresh: bool = False) -> Dict[str, List]:
+    def retrieve(self, *args, force_refresh: bool = False) -> PartData:
         """
         Public function that allows the user to make part requests.
 
@@ -67,7 +54,7 @@ class API:
         logger.debug(f"Retrieving {args}...")
         return self._handler.retrieve(*args, force_refresh=force_refresh)
 
-    def retrieve_all(self, force_refresh: bool = False) -> Dict[str, List]:
+    def retrieve_all(self, force_refresh: bool = False) -> PartData:
         """
         Public function that allows the user to retrieve all supported part types.
 

--- a/pcpartpicker/parse_utils.py
+++ b/pcpartpicker/parse_utils.py
@@ -1,13 +1,13 @@
 import json
 import re
 from decimal import Decimal
-from multiprocessing import Pool
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List
 
 from dacite import from_dict, Config
 from moneyed import Money
 
 from .mappings import part_classes
+from .part_data import PartData
 
 
 def dataclass_from_dict(datatype, dictionary: dict):
@@ -30,10 +30,6 @@ def deserialize_part_data(part_data: Tuple[str, str]) -> list:
     return [dataclass_from_dict(part_classes[part_data[0]], item) for item in deserialized_parts]
 
 
-def parse(part_dict: Dict[str, str], multithreading: bool = True) -> Dict[str, list]:
-    if multithreading:
-        with Pool() as pool:
-            results = pool.map(deserialize_part_data, (item for item in part_dict.items()))
-    else:
-        results = [deserialize_part_data(item) for item in part_dict.items()]
+def parse(part_dict: Dict[str, str]) -> Dict[str, List]:
+    results = [deserialize_part_data(item) for item in part_dict.items()]
     return dict(zip(part_dict.keys(), results))

--- a/pcpartpicker/part_data.py
+++ b/pcpartpicker/part_data.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+import json
+from dataclasses import is_dataclass
+from moneyed import Money
+
+
+class PartData(dict):
+
+    def __init__(self):
+        super().__init__()
+        self.timestamp: datetime = datetime.now()
+
+    def to_json(self) -> str:
+        class CustomEncoder(json.JSONEncoder):
+            def default(self, o):
+                if is_dataclass(o):
+                    return o.__dict__
+                if isinstance(o, Money):
+                    return o.currency.code, str(o.amount)
+                if isinstance(o, datetime):
+                    return str(o)
+                raise TypeError("Not JSON serializable!")
+        return json.dumps(self, indent=4, cls=CustomEncoder)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(file_name: str):
 
 setup(
     name="pcpartpicker",
-    version="2.1.1",
+    version="2.2.0",
     author="Jonathan Vusich",
     author_email="jonathanvusich@gmail.com",
     description="A fast, simple API for PCPartPicker.com.",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,7 +20,6 @@ class APITest(unittest.TestCase):
                                                  "in", "ie", "it", "nz", "uk", "us"})
 
         self.assertEqual(api.region, 'us')
-        self.assertTrue(api.multithreading)
 
     # Ensure that API can be initialized with a different region
     def test_api_region_init(self):
@@ -46,19 +45,3 @@ class APITest(unittest.TestCase):
             api = API()
             api.set_region('oc')
         assert 'Region \'oc\' is not supported for this API!' in str(excinfo.exception)
-
-    def test_api_multithreading_kwd(self):
-        api = API(multithreading=False)
-        self.assertFalse(api.multithreading)
-        self.assertFalse(api._handler.multithreading)
-
-    def test_api_modify_multithreading(self):
-        api = API()
-        self.assertTrue(api.multithreading)
-        self.assertTrue(api._handler._multithreading)
-        api.set_multithreading(False)
-        self.assertFalse(api._handler._multithreading)
-        self.assertFalse(api.multithreading)
-        api.set_multithreading(True)
-        self.assertTrue(api.multithreading)
-        self.assertTrue(api._handler._multithreading)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,10 +1,7 @@
-from pcpartpicker import API
-from pcpartpicker.scraper import Scraper
-from pcpartpicker.parse_utils import parse
-from pcpartpicker.mappings import part_classes
-
-import asyncio
 import unittest
+
+from pcpartpicker import API
+from pcpartpicker.mappings import part_classes
 
 
 class ParserTest(unittest.TestCase):
@@ -23,6 +20,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_uk_tokens(self):
         results = API("uk").retrieve_all()
@@ -30,6 +28,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_nz_tokens(self):
         results = API("nz").retrieve_all()
@@ -37,6 +36,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_it_tokens(self):
         results = API("it").retrieve_all()
@@ -44,6 +44,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_ie_tokens(self):
         results = API("ie").retrieve_all()
@@ -51,6 +52,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_in_tokens(self):
         results = API("in").retrieve_all()
@@ -58,6 +60,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_se_tokens(self):
         results = API("se").retrieve_all()
@@ -65,6 +68,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_fr_tokens(self):
         results = API("fr").retrieve_all()
@@ -72,6 +76,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_es_tokens(self):
         results = API("es").retrieve_all()
@@ -79,6 +84,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_de_tokens(self):
         results = API("de").retrieve_all()
@@ -86,6 +92,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_ca_tokens(self):
         results = API("ca").retrieve_all()
@@ -93,6 +100,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_be_tokens(self):
         results = API("be").retrieve_all()
@@ -100,6 +108,7 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())
 
     def test_au_tokens(self):
         results = API("au").retrieve_all()
@@ -107,3 +116,4 @@ class ParserTest(unittest.TestCase):
             for p in part_data:
                 self.assertIsInstance(p, part_classes[part])
                 self.assertIsNotNone(p.brand)
+        self.assertIsNotNone(results.to_json())


### PR DESCRIPTION
Multithreading was removed because it is buggy depending on the system and version of Python that you are running. Also, the speed gains from using it are negligible now that the data is retrieved from JSON instead of from live HTML.

Also, `api.retrieve()` and `api.retrieve_all()` now return `PartData` objects, which contains a timestamp and a `to_json()` method. This was a requested feature that did indeed seem missing.

Resolves #33, #37.