### PR TITLE
Fix CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=5.4.0
 pytest-asyncio
 pytest-timeout
 pytest-cov


### PR DESCRIPTION
Travis is failing on Linux due to pytest already being installed (apparently).